### PR TITLE
Support kind env with different names in gen_pki.sh

### DIFF
--- a/docs/manually-setup-cn.md
+++ b/docs/manually-setup-cn.md
@@ -24,7 +24,7 @@ kubectl config use-context kind-kind
    然后存储在 secret  `upstream-pki` 中.
 
 ```console
-$ sh $KUBEZOO_PATH/hack/lib/gen_pki.sh
+$ bash $KUBEZOO_PATH/hack/lib/gen_pki.sh
 ```
 
 如果上述命令成功运行，你将看到下面两个 secret:

--- a/docs/manually-setup.md
+++ b/docs/manually-setup.md
@@ -27,7 +27,7 @@ upstream cluster, which will need to be fetched from the upstream cluster and
 store in the secret `upstream-pki`
 
 ```console
-$ sh $KUBEZOO_PATH/hack/lib/gen_pki.sh
+$ bash $KUBEZOO_PATH/hack/lib/gen_pki.sh
 ```
 
 Upon success, you should be able to see the two secrets


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/enhancements
-->

Bug fixes

#### What this PR does / why we need it:

Support environments with multiple kind clusters, and use the currently selected cluster context.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
The script is no longer compatible with `dash`. `bash` is required.