### PR TITLE
feat: validate tenant name

### DIFF
--- a/docs/manually-setup-cn.md
+++ b/docs/manually-setup-cn.md
@@ -95,6 +95,8 @@ $ kubectl apply -f config/setup/sample_tenant.yaml --context zoo
 tenant.tenant.kubezoo.io/111111 created
 ```
 
+租户名称必须是有效的6字符[RFC 1123][rfc1123-label]DNS标签前缀(`[A-Za-z0-9][A-Za-z0-9\-]{5}`)。
+
 ### 获取租户的 kubeconfigs 文件
 
 ```console
@@ -141,3 +143,5 @@ default              kubezoo-etcd-0                               1/1     Runnin
 default              test                                         1/1     Running   0          2m41s
 ...
 ```
+
+[rfc1123-label]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names

--- a/docs/manually-setup.md
+++ b/docs/manually-setup.md
@@ -99,6 +99,8 @@ $ kubectl apply -f config/setup/sample_tenant.yaml --context zoo
 tenant.tenant.kubezoo.io/111111 created
 ```
 
+The tenant name must be a valid 6-character [RFC 1123][rfc1123-label] DNS label prefix (`[A-Za-z0-9][A-Za-z0-9\-]{5}`).
+
 ### Get the kubeconfigs of the tenant
 
 ```console
@@ -145,3 +147,5 @@ default              kubezoo-etcd-0                               1/1     Runnin
 default              test                                         1/1     Running   0          2m41s
 ...
 ```
+
+[rfc1123-label]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names

--- a/pkg/rest/strategy.go
+++ b/pkg/rest/strategy.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"github.com/kubewharf/kubezoo/pkg/apis/tenant/v1alpha1"
+	"github.com/kubewharf/kubezoo/pkg/util"
 )
 
 // NewStrategy creates and returns a tenantStrategy instance
@@ -76,6 +77,17 @@ func (tenantStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obj
 }
 
 func (tenantStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	tenant := obj.(*v1alpha1.Tenant)
+	err := util.ValidateTenantName(tenant.Name)
+	if err != nil {
+		return field.ErrorList{&field.Error{
+			Type:     field.ErrorTypeInvalid,
+			Field:    "name",
+			BadValue: tenant.Name,
+			Detail:   *err,
+		}}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
Tenant name should be validated before they result in generation of unparsable namespaces

#### Which issue(s) this PR fixes:
Fixes #12 

```
$ kubectl --context zoo apply -f bad-tenant.yaml
The Tenant "aasdf" is invalid: name: Invalid value: "aasdf": tenant ID must be exactly 6 characters
```