### PR TITLE
fix: change node name with tenantID prefix when update node cause con…

### DIFF
--- a/cmd/kubezoo/app/apigroups.go
+++ b/cmd/kubezoo/app/apigroups.go
@@ -11,6 +11,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	authorizationv1beta1 "k8s.io/api/authorization/v1beta1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchapiv1 "k8s.io/api/batch/v1"
@@ -1094,6 +1095,24 @@ var nonLegacyGroups = []common.APIGroupConfig{
 				},
 				"horizontalpodautoscalers/status": {
 					Kind:            autoscalingv2beta2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+					Resource:        "horizontalpodautoscalers",
+					Subresource:     "status",
+					NamespaceScoped: true,
+					ShortNames:      []string{"hpa"},
+					NewFunc:         func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
+				},
+			},
+			"v2": {
+				"horizontalpodautoscalers": {
+					Kind:            autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
+					Resource:        "horizontalpodautoscalers",
+					NamespaceScoped: true,
+					ShortNames:      []string{"hpa"},
+					NewFunc:         func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
+					NewListFunc:     func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
+				},
+				"horizontalpodautoscalers/status": {
+					Kind:            autoscalingv2.SchemeGroupVersion.WithKind("HorizontalPodAutoscaler"),
 					Resource:        "horizontalpodautoscalers",
 					Subresource:     "status",
 					NamespaceScoped: true,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -423,7 +423,7 @@ func (tc *TenantController) syncClusterResourceQuota(tenantID string) error {
 	tenant, err := tc.tenantClient.Tenants().Get(context.TODO(), tenantID, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			nerr := tc.tenantClient.Tenants().Delete(context.TODO(), tenantQuotaName, metav1.DeleteOptions{})
+			nerr := tc.clusterquotaCli.ClusterResourceQuotas().Delete(context.TODO(), tenantQuotaName, metav1.DeleteOptions{})
 			if apierrors.IsNotFound(nerr) {
 				// ignore notFound
 				nerr = nil

--- a/pkg/convert/init.go
+++ b/pkg/convert/init.go
@@ -93,6 +93,10 @@ func InitConvertors(checkGroupKind util.CheckGroupKindFunc, listTenantCRDs ListT
 			Group: "policy",
 			Kind:  "PodSecurityPolicy",
 		}: nopeConvertor,
+		{
+			Group: "",
+			Kind:  "Node",
+		}: nopeConvertor,
 	}
 	nativeConvertor = NewNativeObjectConvertor(defaultConvertor, nativeKindToConvertors)
 	customConvertor = NewCrossReferenceConverter(defaultConvertor, NewCustomResourceTransformer())


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes/enhancements

#### What this PR does / why we need it:
1.when I try to label k8s node with labels, error of conflict met. Try to fix to update node with tenant [df03592](https://github.com/kubewharf/kubezoo/pull/30/commits/df035922ca4993e1a65427fa1c624ea28c5eda32)
```shell 
$ kubectl --kubeconfig 111111.kubeconfig  label nodes kubezoo-e2e-test-control-plane labelinzoo=zoo1 
Error from server (Conflict): Operation cannot be fulfilled on nodes "kubezoo-e2e-test-control-plane": StorageError: invalid object, Code: 4, Key: /registry/minions/kubezoo-e2e-test-control-plane, ResourceVersion: 0, AdditionalErrorMsg: Precondition failed: UID in precondition: 99b48dc6-626a-45ad-8624-95d540863b87, UID in object meta:
```
2.when I try to get all resource in tenant, error of resource horizontalpodautoscalers.v2.autoscaling notfound got. Try to fix it [e679b83](https://github.com/kubewharf/kubezoo/pull/30/commits/e679b83c3e03b0ce02f97d2064cbdb70612e48aa).
```shell 
$ kubectl --kubeconfig 111111.kubeconfig   get all -A
Error from server (NotFound): Unable to list "autoscaling/v2, Resource=horizontalpodautoscalers": the server could not find the requested resource
```

3.when I delete tenant and found the clusterresourcequotas is still exist. found use the wrong client. [69c58f5](https://github.com/kubewharf/kubezoo/pull/30/commits/69c58f51b2f0eca40af977487fc8472edab448a4)
```shell
$ kubectl --kubeconfig 111111.kubeconfig  delete  tenants.tenant.kubezoo.io 111111
tenant.tenant.kubezoo.io "111111" deleted
$ kubectl --context  kind-kubezoo-e2e-test  get clusterresourcequotas.quota.kubezoo.io
NAME                          AGE
kubezoo-tenant-quota-111111   47h
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
