### PR TITLE
ci: add github actions workflow to run go envtest e2e tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,21 @@
+permissions: {}
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  "e2e-tests":
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          check-latest: true
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - run: make e2e

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 DOCKER_BUILD_ARGS = --build-arg GIT_VERSION=${GIT_VERSION}
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.19
+ENVTEST_K8S_VERSION = 1.29.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -58,9 +58,12 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+## Tool Versions
+ENVTEST_VERSION ?= release-0.17
+
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest,./)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION),./)
 
 .PHONY: kube-codegen
 kube-codegen:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
 go get $(2) ;\
-cd $(shell go list -f '{{ .Dir }}' -m $(2)) ;\
+cd $$(go list -f '{{ .Dir }}' -m $(2)) ;\
 GOBIN=$(PROJECT_DIR)/bin go install $(3) ;\
 rm -rf $$TMP_DIR ;\
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubewharf/kubezoo
 
-go 1.18
+go 1.21
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
#### What type of PR is this?

ci enhancement

#### What this PR does / why we need it:

Runs the remaining tests, followup to

* https://github.com/kubewharf/kubezoo/pull/39

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

I had to update go, kubebuilder, and k8s to make this run. If updating go is not acceptable, please tell and I'll think of a different approach.

The issue that forces me to update go is described in my description of #39 .